### PR TITLE
fix rounding bug in Gaussian kernel and add format arg to export_csv

### DIFF
--- a/pygwr/gaussian.py
+++ b/pygwr/gaussian.py
@@ -18,7 +18,6 @@ class Gaussian:
         Computes the Gaussian kernel for the matrices X and Z.
         """
         X, Z = np.matrix(X, dtype="float32"), np.matrix(Z, dtype="float32")
-        n, m = X.shape[0], Z.shape[0]
-        XX, ZZ = np.multiply(X, X).sum(axis=1), np.multiply(Z, Z).sum(axis=1)
-        d = np.tile(XX, (1, m)) + np.tile(ZZ.T, (n, 1)) - 2 * X * Z.T
+        n = X.shape[0]
+        d = np.square(np.tile(Z,(n,1)) - X).sum(axis=1)
         return np.array(np.exp(-d.T / (2. * sigma * sigma)))

--- a/pygwr/gwr.py
+++ b/pygwr/gwr.py
@@ -182,7 +182,7 @@ class GWRResultSet(list):
     A collection of GWR results.
     """
     
-    def export_csv(self, path):
+    def export_csv(self, path,fmt='%f'):
         """
         Exports the GWR result set into a CSV text file.
         """
@@ -212,20 +212,20 @@ class GWRResultSet(list):
         # Go through all the estimation points and create a feature for each
         for r in self:
             for i in range(ndims):
-                f.write("%f\t" % r.estimation_pt[i])
+                f.write((fmt+"\t") % r.estimation_pt[i])
             for i in range(n-1):
-                f.write("%f\t" % r.sample[i])
+                f.write((fmt+"\t") % r.sample[i])
             for i in range(n):
-                f.write("%f\t" % r.params[i])
+                f.write((fmt+"\t") % r.params[i])
             for i in range(n):
-                f.write("%f\t" % r.result.tvalues[i])
+                f.write((fmt+"\t") % r.result.tvalues[i])
             for i in range(n):
-                f.write("%f\t" % r.result.pvalues[i])
+                f.write((fmt+"\t") % r.result.pvalues[i])
             if r.idx != None:
-                f.write("%f\t" % r.gwr.targets[r.idx])
+                f.write((fmt+"\t") % r.gwr.targets[r.idx])
             else:
                 f.write("\t")
-            f.write("%f\n" % r.prediction)
+            f.write((fmt+"\n") % r.prediction)
         f.close()
     
 


### PR DESCRIPTION
Changed method for calculating squared distance in Gaussian kernel
class. The old method was leading to weighting errors due to subtraction of large
numbers (e.g. when locations were given in UTM coordinates). Also added
a fmt string to allow for other formats when dumping to csv.
